### PR TITLE
Support for "class" Attribute Added

### DIFF
--- a/lib/include/tinytmxObject.hpp
+++ b/lib/include/tinytmxObject.hpp
@@ -60,6 +60,9 @@ namespace tinytmx
         /// Get the type of the object. An arbitrary string. (defaults to "")
         [[nodiscard]] std::string const &GetType() const { return type; }
 
+        /// Get the class of the object. Introduced in Tiled 1.9 and meant to supersede type
+        [[nodiscard]] std::string const &GetClass() const { return class_; }
+
         /// Get the left side of the object, in pixels.
         [[nodiscard]] float GetX() const { return x; }
 
@@ -152,6 +155,7 @@ namespace tinytmx
 
         std::string name;
         std::string type;
+        std::string class_;
         std::string t_template;
 
         /// @cond INTERNAL

--- a/lib/src/tinytmxObject.cpp
+++ b/lib/src/tinytmxObject.cpp
@@ -156,6 +156,10 @@ namespace tinytmx {
             type = objectElem->Attribute("type");
         }
 
+        if (objectElem->Attribute("class")) {
+            class_ = objectElem->Attribute("class");
+        }
+
         objectElem->QueryIntAttribute("id", &id);
         objectElem->QueryFloatAttribute("x", &x);
         objectElem->QueryFloatAttribute("y", &y);


### PR DESCRIPTION
Adds support for the "class" attribute that was renamed from "type" in Tiled 1.9. Leaves GetType() in tact for backwards compatibility and adds a new field called "class_" that behaves the same way.

https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#object